### PR TITLE
Refactor find_with_nhk to return FindWithNhkResult enum

### DIFF
--- a/examples/debug_kousei.rs
+++ b/examples/debug_kousei.rs
@@ -1,20 +1,41 @@
-use jaydar::find_with_nhk;
+use jaydar::{find_with_nhk, FindWithNhkResult};
 
 fn main() {
     let results = find_with_nhk("こうせい");
     
     println!("Results for こうせい:");
-    for word in &results {
-        println!("  Text: {}, Pitch: {:?}, True homophone: {}", 
-            word.text, word.pitch_accent, word.is_true_homophone);
+    match &results {
+        FindWithNhkResult::MultipleMatches { homophones } => {
+            for word in homophones {
+                println!("  Text: {}, Pitch: {:?}, True homophone: {}", 
+                    word.text, word.pitch_accent, word.is_true_homophone);
+            }
+        }
+        FindWithNhkResult::UniqueMatch { .. } => {
+            println!("  Unexpected UniqueMatch for reading search");
+        }
     }
     
     println!("\n\nResults for 構成:");
     let results2 = find_with_nhk("構成");
-    for word in &results2 {
-        if word.text == "構成" || word.text == "後世" {
-            println!("  Text: {}, Pitch: {:?}, True homophone: {}", 
-                word.text, word.pitch_accent, word.is_true_homophone);
+    match &results2 {
+        FindWithNhkResult::UniqueMatch { pitch_accent, true_homophones, different_pitch_homophones } => {
+            println!("  Target pitch: {:?}", pitch_accent);
+            println!("  True homophones:");
+            for word in true_homophones {
+                if word.text == "構成" {
+                    println!("    Text: {}, Pitch: {:?}", word.text, word.pitch_accent);
+                }
+            }
+            println!("  Fake homophones:");
+            for word in different_pitch_homophones {
+                if word.text == "後世" {
+                    println!("    Text: {}, Pitch: {:?}", word.text, word.pitch_accent);
+                }
+            }
+        }
+        FindWithNhkResult::MultipleMatches { .. } => {
+            println!("  Unexpected MultipleMatches for specific word search");
         }
     }
 }

--- a/examples/demo_with_pitch.rs
+++ b/examples/demo_with_pitch.rs
@@ -1,31 +1,51 @@
-use jaydar::{find_with_nhk, WordFrequencyWithPitch};
+use jaydar::{find_with_nhk, FindWithNhkResult, WordFrequencyWithPitch};
 
 fn main() {
     // Example 1: Show pitch accent differences in こうせい
     println!("Homophones for 'こうせい' with pitch accent:");
     let results = find_with_nhk("こうせい");
-    print_results_with_pitch(&results);
+    print_results(&results);
     
     println!("\n{}\n", "=".repeat(70));
     
     // Example 2: Search for 構成 (pitch 0) - shows "fake homophones"
     println!("Homophones for '構成' (pitch 0) - marking fake homophones:");
     let results = find_with_nhk("構成");
-    print_results_with_pitch(&results);
+    print_results(&results);
     
     println!("\n{}\n", "=".repeat(70));
     
     // Example 3: Search for 後世 (pitch 1) - different fake homophones
     println!("Homophones for '後世' (pitch 1) - marking fake homophones:");
     let results = find_with_nhk("後世");
-    print_results_with_pitch(&results);
+    print_results(&results);
     
     println!("\n{}\n", "=".repeat(70));
     
     // Example 4: Another common word with pitch variations
     println!("Homophones for 'はし' with pitch accent:");
     let results = find_with_nhk("はし");
-    print_results_with_pitch(&results);
+    print_results(&results);
+}
+
+fn print_results(results: &FindWithNhkResult) {
+    match results {
+        FindWithNhkResult::UniqueMatch { pitch_accent, true_homophones, different_pitch_homophones } => {
+            println!("Type: Unique match (searched for specific word)");
+            println!("Target word pitch accent: {:?}", pitch_accent);
+            println!("\nTrue homophones (same pitch):");
+            print_results_with_pitch(true_homophones);
+            
+            if !different_pitch_homophones.is_empty() {
+                println!("\nFake homophones (different pitch):");
+                print_results_with_pitch(different_pitch_homophones);
+            }
+        }
+        FindWithNhkResult::MultipleMatches { homophones } => {
+            println!("Type: Multiple matches (searched by reading)");
+            print_results_with_pitch(homophones);
+        }
+    }
 }
 
 fn print_results_with_pitch(results: &[WordFrequencyWithPitch]) {

--- a/examples/test_nihongo.rs
+++ b/examples/test_nihongo.rs
@@ -1,0 +1,25 @@
+use jaydar::{find_with_nhk, FindWithNhkResult};
+
+fn main() {
+    let results = find_with_nhk("にほんご");
+    
+    match &results {
+        FindWithNhkResult::UniqueMatch { pitch_accent, true_homophones, different_pitch_homophones } => {
+            println!("Got UniqueMatch for にほんご");
+            println!("Pitch accent: {:?}", pitch_accent);
+            println!("True homophones: {} words", true_homophones.len());
+            println!("Different pitch homophones: {} words", different_pitch_homophones.len());
+            
+            for word in true_homophones {
+                println!("  {} ({}) - pitch: {:?}", word.text, word.reading, word.pitch_accent);
+            }
+        }
+        FindWithNhkResult::MultipleMatches { homophones } => {
+            println!("Got MultipleMatches for にほんご");
+            println!("Found {} homophones", homophones.len());
+            for word in homophones {
+                println!("  {} ({}) - pitch: {:?}", word.text, word.reading, word.pitch_accent);
+            }
+        }
+    }
+}

--- a/examples/test_teido.rs
+++ b/examples/test_teido.rs
@@ -1,49 +1,56 @@
-use jaydar::find_with_nhk;
+use jaydar::{find_with_nhk, FindWithNhkResult};
 
 fn main() {
     println!("Testing 程度 (ていど) for multiple pitch accents:");
     
     let results = find_with_nhk("ていど");
     
-    for word in &results {
-        if word.text == "程度" {
-            println!("\nFound 程度:");
-            println!("  Reading: {}", word.reading);
-            println!("  Pitch accents: {:?}", word.pitch_accent);
-            println!("  Frequency: {}", word.frequency_score);
-            println!("  Common: {}", word.is_common);
-            
-            if word.pitch_accent.len() > 1 {
-                println!("  ✓ Successfully has multiple pitch accents!");
-            } else {
-                println!("  ✗ Only has {} pitch accent(s)", word.pitch_accent.len());
+    match &results {
+        FindWithNhkResult::MultipleMatches { homophones } => {
+            for word in homophones {
+                if word.text == "程度" {
+                    println!("\nFound 程度:");
+                    println!("  Reading: {}", word.reading);
+                    println!("  Pitch accents: {:?}", word.pitch_accent);
+                    println!("  Frequency: {}", word.frequency_score);
+                    println!("  Common: {}", word.is_common);
+                    
+                    if word.pitch_accent.len() > 1 {
+                        println!("  ✓ Successfully has multiple pitch accents!");
+                    } else {
+                        println!("  ✗ Only has {} pitch accent(s)", word.pitch_accent.len());
+                    }
+                    
+                    if word.pitch_accent.contains(&1) && word.pitch_accent.contains(&0) {
+                        println!("  ✓ Has both pitch accents 1 and 0 as expected!");
+                    }
+                }
             }
             
-            if word.pitch_accent.contains(&1) && word.pitch_accent.contains(&0) {
-                println!("  ✓ Has both pitch accents 1 and 0 as expected!");
+            println!("\nAll homophones of ていど:");
+            for (i, word) in homophones.iter().enumerate() {
+                if i < 10 {
+                    let pitch_str = if word.pitch_accent.is_empty() {
+                        "?".to_string()
+                    } else {
+                        word.pitch_accent.iter()
+                            .map(|p| p.to_string())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    };
+                    
+                    println!("{:<10} ({:<10}) - pitch: {:<10} freq: {:<8} {}",
+                        word.text,
+                        word.reading,
+                        pitch_str,
+                        word.frequency_score,
+                        if word.is_true_homophone { "✓" } else { "✗" }
+                    );
+                }
             }
         }
-    }
-    
-    println!("\nAll homophones of ていど:");
-    for (i, word) in results.iter().enumerate() {
-        if i < 10 {
-            let pitch_str = if word.pitch_accent.is_empty() {
-                "?".to_string()
-            } else {
-                word.pitch_accent.iter()
-                    .map(|p| p.to_string())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            };
-            
-            println!("{:<10} ({:<10}) - pitch: {:<10} freq: {:<8} {}",
-                word.text,
-                word.reading,
-                pitch_str,
-                word.frequency_score,
-                if word.is_true_homophone { "✓" } else { "✗" }
-            );
+        FindWithNhkResult::UniqueMatch { .. } => {
+            println!("Unexpected: Got UniqueMatch for reading search");
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,8 @@
 use std::collections::HashMap;
 
-mod nhk_data;
 pub mod kana_utils;
 mod katakana_support;
-
+mod nhk_data;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct WordFrequency {
@@ -19,8 +18,29 @@ pub struct WordFrequencyWithPitch {
     pub reading: String,
     pub frequency_score: u32,
     pub is_common: bool,
-    pub pitch_accent: Vec<u8>,  // Multiple pitch accents in order of preference
-    pub is_true_homophone: bool,  // false if different pitch from query word
+    pub pitch_accent: Vec<u8>, // Multiple pitch accents in order of preference
+    pub is_true_homophone: bool, // false if different pitch from query word
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct NewWordFrequencyWithPitch {
+    pub text: String,
+    pub reading: String,
+    pub frequency_score: u32,
+    pub is_common: bool,
+    pub pitch_accent: Vec<u8>, // Multiple pitch accents in order of preference
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum FindWithNhkResult {
+    UniqueMatch {
+        pitch_accent: Vec<u8>,
+        true_homophones: Vec<WordFrequencyWithPitch>,
+        different_pitch_homophones: Vec<WordFrequencyWithPitch>,
+    },
+    MultipleMatches {
+        homophones: Vec<WordFrequencyWithPitch>,
+    },
 }
 
 pub fn find(word: &str) -> Vec<WordFrequency> {
@@ -30,43 +50,43 @@ pub fn find(word: &str) -> Vec<WordFrequency> {
 
 pub(crate) fn calculate_frequency_score(priority: &jmdict::Priority) -> u32 {
     use jmdict::PriorityInCorpus::*;
-    
+
     let mut score = 0u32;
-    
+
     // Base score from frequency bucket (1-48, where 1 is most common)
     if priority.frequency_bucket > 0 {
         score += (50 - priority.frequency_bucket as u32) * 1000;
     }
-    
+
     // Additional scores from different corpora
     match priority.news {
         Primary => score += 500,
         Secondary => score += 200,
         Absent => {}
     }
-    
+
     match priority.ichimango {
         Primary => score += 500,
         Secondary => score += 200,
         Absent => {}
     }
-    
+
     match priority.loanwords {
         Primary => score += 300,
         Secondary => score += 100,
         Absent => {}
     }
-    
+
     match priority.additional {
         Primary => score += 400,
         Secondary => score += 150,
         Absent => {}
     }
-    
+
     score
 }
 
-pub fn find_with_nhk(word: &str) -> Vec<WordFrequencyWithPitch> {
+pub fn find_with_nhk(word: &str) -> FindWithNhkResult {
     // Convert katakana to hiragana if needed
     let search_word = if kana_utils::contains_katakana(word) {
         kana_utils::katakana_to_hiragana(word)
@@ -75,76 +95,94 @@ pub fn find_with_nhk(word: &str) -> Vec<WordFrequencyWithPitch> {
     };
     let original_word = word;
     let hiragana_word = search_word.as_str();
-    
+
     let mut homophones = Vec::new();
     let mut reading_to_words: HashMap<String, Vec<(String, u32, bool, Vec<u8>)>> = HashMap::new();
-    
+
     // First, find the target word's pitch accent
     let mut target_pitches: Vec<u8> = Vec::new();
     let mut target_readings = Vec::new();
-    
+    let mut is_unique_match = false;
+
     // If input was katakana, we want to search for the hiragana reading
     if kana_utils::contains_katakana(original_word) {
         target_readings.push(hiragana_word.to_string());
     }
-    
+
+    // Check if word is a specific text (kanji) rather than a reading
     for entry in jmdict::entries() {
         // Check kanji elements
         for kanji in entry.kanji_elements() {
             if kanji.text == original_word {
+                is_unique_match = true;
                 for reading in entry.reading_elements() {
                     if !target_readings.contains(&reading.text.to_string()) {
                         target_readings.push(reading.text.to_string());
                     }
-                    
+
                     // Get pitch accents for this word
                     if target_pitches.is_empty() {
                         target_pitches = nhk_data::get_pitch_accents(reading.text, kanji.text);
                     }
-                    
+
                     let freq_score = calculate_frequency_score(&reading.priority);
                     let pitches = nhk_data::get_pitch_accents(reading.text, kanji.text);
                     let key = reading.text.to_string();
-                    reading_to_words.entry(key)
-                        .or_insert_with(Vec::new)
-                        .push((kanji.text.to_string(), freq_score, reading.priority.is_common(), pitches));
+                    reading_to_words.entry(key).or_insert_with(Vec::new).push((
+                        kanji.text.to_string(),
+                        freq_score,
+                        reading.priority.is_common(),
+                        pitches,
+                    ));
                 }
             }
         }
-        
+
         // Check reading elements
         for reading in entry.reading_elements() {
             if reading.text == original_word || reading.text == hiragana_word {
-                if !target_readings.contains(&reading.text.to_string()) {
-                    target_readings.push(reading.text.to_string());
+                if !is_unique_match {
+                    // Only mark as reading-based search if we didn't find a kanji match
+                    if !target_readings.contains(&reading.text.to_string()) {
+                        target_readings.push(reading.text.to_string());
+                    }
+
+                    // Get pitch accents for kana-only word
+                    if target_pitches.is_empty() && entry.kanji_elements().count() == 0 {
+                        target_pitches = nhk_data::get_pitch_accents(reading.text, reading.text);
+                    }
                 }
-                
-                // Get pitch accents for kana-only word
-                if target_pitches.is_empty() {
-                    target_pitches = nhk_data::get_pitch_accents(reading.text, reading.text);
-                }
-                
+
                 let freq_score = calculate_frequency_score(&reading.priority);
                 let key = reading.text.to_string();
-                
+
                 if entry.kanji_elements().count() == 0 {
                     let pitches = nhk_data::get_pitch_accents(reading.text, reading.text);
-                    reading_to_words.entry(key)
-                        .or_insert_with(Vec::new)
-                        .push((reading.text.to_string(), freq_score, reading.priority.is_common(), pitches));
+                    reading_to_words.entry(key).or_insert_with(Vec::new).push((
+                        reading.text.to_string(),
+                        freq_score,
+                        reading.priority.is_common(),
+                        pitches,
+                    ));
                 } else {
                     for kanji in entry.kanji_elements() {
                         let kanji_freq_score = calculate_frequency_score(&kanji.priority);
                         let pitches = nhk_data::get_pitch_accents(reading.text, kanji.text);
-                        reading_to_words.entry(key.clone())
+                        reading_to_words
+                            .entry(key.clone())
                             .or_insert_with(Vec::new)
-                            .push((kanji.text.to_string(), kanji_freq_score, kanji.priority.is_common(), pitches));
+                            .push((
+                                kanji.text.to_string(),
+                                kanji_freq_score,
+                                kanji.priority.is_common(),
+                                pitches,
+                            ));
                     }
                 }
             }
         }
     }
-    
+
     // Second pass: collect all words with the same readings
     if !target_readings.is_empty() {
         for entry in jmdict::entries() {
@@ -152,26 +190,35 @@ pub fn find_with_nhk(word: &str) -> Vec<WordFrequencyWithPitch> {
                 if target_readings.contains(&reading.text.to_string()) {
                     let freq_score = calculate_frequency_score(&reading.priority);
                     let key = reading.text.to_string();
-                    
+
                     if entry.kanji_elements().count() == 0 {
                         let pitches = nhk_data::get_pitch_accents(reading.text, reading.text);
-                        reading_to_words.entry(key)
-                            .or_insert_with(Vec::new)
-                            .push((reading.text.to_string(), freq_score, reading.priority.is_common(), pitches));
+                        reading_to_words.entry(key).or_insert_with(Vec::new).push((
+                            reading.text.to_string(),
+                            freq_score,
+                            reading.priority.is_common(),
+                            pitches,
+                        ));
                     } else {
                         for kanji in entry.kanji_elements() {
                             let kanji_freq_score = calculate_frequency_score(&kanji.priority);
                             let pitches = nhk_data::get_pitch_accents(reading.text, kanji.text);
-                            reading_to_words.entry(key.clone())
+                            reading_to_words
+                                .entry(key.clone())
                                 .or_insert_with(Vec::new)
-                                .push((kanji.text.to_string(), kanji_freq_score, kanji.priority.is_common(), pitches));
+                                .push((
+                                    kanji.text.to_string(),
+                                    kanji_freq_score,
+                                    kanji.priority.is_common(),
+                                    pitches,
+                                ));
                         }
                     }
                 }
             }
         }
     }
-    
+
     // If input was katakana, also include katakana entries
     if kana_utils::contains_katakana(original_word) {
         // Check if the katakana word exists in JMDict
@@ -181,39 +228,47 @@ pub fn find_with_nhk(word: &str) -> Vec<WordFrequencyWithPitch> {
                     // Found the katakana entry
                     let freq_score = calculate_frequency_score(&kanji.priority);
                     let pitches = nhk_data::get_pitch_accents(hiragana_word, original_word);
-                    reading_to_words.entry(hiragana_word.to_string())
+                    reading_to_words
+                        .entry(hiragana_word.to_string())
                         .or_insert_with(Vec::new)
-                        .push((original_word.to_string(), freq_score, kanji.priority.is_common(), pitches));
+                        .push((
+                            original_word.to_string(),
+                            freq_score,
+                            kanji.priority.is_common(),
+                            pitches,
+                        ));
                     break;
                 }
             }
         }
-        
+
         // Also add the katakana itself even if not in JMDict
-        let has_katakana_entry = reading_to_words.get(hiragana_word)
+        let has_katakana_entry = reading_to_words
+            .get(hiragana_word)
             .map(|words| words.iter().any(|(text, _, _, _)| text == original_word))
             .unwrap_or(false);
-            
+
         if !has_katakana_entry {
-            reading_to_words.entry(hiragana_word.to_string())
+            reading_to_words
+                .entry(hiragana_word.to_string())
                 .or_insert_with(Vec::new)
                 .push((original_word.to_string(), 0, false, vec![]));
         }
     }
-    
+
     // Convert to output format and deduplicate
     let mut seen = std::collections::HashSet::new();
     for (reading, words) in reading_to_words {
         for (text, freq_score, is_common, pitches) in words {
             let key = (text.clone(), reading.clone());
             if seen.insert(key) {
-                let is_true_homophone = if !target_pitches.is_empty() && !pitches.is_empty() {
-                    // Check if any pitch matches
+                let is_true_homophone = if is_unique_match && !target_pitches.is_empty() && !pitches.is_empty() {
+                    // For unique match, check if pitch matches the target
                     target_pitches.iter().any(|tp| pitches.contains(tp))
                 } else {
-                    true  // If we don't know pitch, assume it's a true homophone
+                    true // For reading-based search, all are true homophones
                 };
-                
+
                 homophones.push(WordFrequencyWithPitch {
                     text,
                     reading: reading.clone(),
@@ -225,11 +280,44 @@ pub fn find_with_nhk(word: &str) -> Vec<WordFrequencyWithPitch> {
             }
         }
     }
-    
+
     // Sort by frequency score (higher is more common)
     homophones.sort_by(|a, b| b.frequency_score.cmp(&a.frequency_score));
-    
-    homophones
+
+    // Return appropriate result based on match type
+    if is_unique_match {
+        let true_homophones = homophones.iter()
+            .filter(|w| w.is_true_homophone)
+            .cloned()
+            .collect();
+        let different_pitch_homophones = homophones.iter()
+            .filter(|w| !w.is_true_homophone)
+            .cloned()
+            .collect();
+        
+        FindWithNhkResult::UniqueMatch {
+            pitch_accent: target_pitches,
+            true_homophones,
+            different_pitch_homophones,
+        }
+    } else {
+        // Check if reading uniquely identifies a single word
+        let unique_texts: std::collections::HashSet<String> = homophones.iter()
+            .map(|w| w.text.clone())
+            .collect();
+        
+        if unique_texts.len() == 1 && !homophones.is_empty() {
+            // This reading uniquely identifies one word
+            let unique_word = &homophones[0];
+            FindWithNhkResult::UniqueMatch {
+                pitch_accent: unique_word.pitch_accent.clone(),
+                true_homophones: homophones,
+                different_pitch_homophones: vec![],
+            }
+        } else {
+            FindWithNhkResult::MultipleMatches { homophones }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -240,27 +328,27 @@ mod tests {
     fn test_find_homophones() {
         let results = find("かう");
         assert!(!results.is_empty());
-        
+
         // Should find multiple homophones like 買う, 飼う, 支う, etc.
         let texts: Vec<&str> = results.iter().map(|w| w.text.as_str()).collect();
         assert!(texts.contains(&"買う"));
         assert!(texts.contains(&"飼う"));
-        
+
         // Check that they're sorted by frequency
         for i in 1..results.len() {
-            assert!(results[i-1].frequency_score >= results[i].frequency_score);
+            assert!(results[i - 1].frequency_score >= results[i].frequency_score);
         }
     }
 
     #[test]
     fn test_common_words_marked() {
         let results = find("こうせい");
-        
+
         // Find common words
         let kousei = results.iter().find(|w| w.text == "構成");
         assert!(kousei.is_some());
         assert!(kousei.unwrap().is_common);
-        
+
         let kousei2 = results.iter().find(|w| w.text == "公正");
         assert!(kousei2.is_some());
         assert!(kousei2.unwrap().is_common);
@@ -269,11 +357,11 @@ mod tests {
     #[test]
     fn test_frequency_ranking() {
         let results = find("こうせい");
-        
+
         // Common words should rank higher
         let kousei_idx = results.iter().position(|w| w.text == "構成").unwrap();
         let kousetsu_idx = results.iter().position(|w| w.text == "校正").unwrap_or(999);
-        
+
         // 構成 should rank higher than 校正
         assert!(kousei_idx < kousetsu_idx);
     }
@@ -282,8 +370,8 @@ mod tests {
     fn test_katakana_input() {
         let results = find("カイ");
         assert!(!results.is_empty());
-        
-        // Should find kanji/hiragana homophones  
+
+        // Should find kanji/hiragana homophones
         let texts: Vec<&str> = results.iter().map(|w| w.text.as_str()).collect();
         assert!(texts.iter().any(|t| t.contains("会")));
         assert!(texts.iter().any(|t| t.contains("回")));
@@ -292,52 +380,65 @@ mod tests {
 
     #[test]
     fn test_with_nhk() {
-        // Test searching by reading - all should be true homophones
+        // Test searching by reading - should return MultipleMatches
         let results = find_with_nhk("こうせい");
-        assert!(!results.is_empty());
-        
-        // Find entries with pitch data
-        let kousei = results.iter().find(|w| w.text == "構成");
-        assert!(kousei.is_some());
-        
-        let kousei = kousei.unwrap();
-        assert!(!kousei.pitch_accent.is_empty());
-        
-        // When searching by reading, all should be true homophones
-        for word in &results {
-            assert!(word.is_true_homophone);
-        }
-        
-        // Test searching by specific word - should mark different pitch as fake
-        let results2 = find_with_nhk("構成");
-        let kousei_by_word = results2.iter().find(|w| w.text == "構成");
-        let kousei2_by_word = results2.iter().find(|w| w.text == "後世");
-        
-        if let (Some(k1), Some(k2)) = (kousei_by_word, kousei2_by_word) {
-            assert!(k1.is_true_homophone); // Same word should be true
-            if !k1.pitch_accent.is_empty() && !k2.pitch_accent.is_empty() {
-                // Different pitch should be fake homophone
-                let have_common_pitch = k1.pitch_accent.iter()
-                    .any(|p| k2.pitch_accent.contains(p));
-                assert_eq!(k2.is_true_homophone, have_common_pitch);
+        match results {
+            FindWithNhkResult::MultipleMatches { homophones } => {
+                assert!(!homophones.is_empty());
+                
+                // Find entries with pitch data
+                let kousei = homophones.iter().find(|w| w.text == "構成");
+                assert!(kousei.is_some());
+                
+                let kousei = kousei.unwrap();
+                assert!(!kousei.pitch_accent.is_empty());
+                
+                // When searching by reading, all should be true homophones
+                for word in &homophones {
+                    assert!(word.is_true_homophone);
+                }
             }
+            _ => panic!("Expected MultipleMatches for reading search")
+        }
+
+        // Test searching by specific word - should return UniqueMatch
+        let results2 = find_with_nhk("構成");
+        match results2 {
+            FindWithNhkResult::UniqueMatch { pitch_accent, true_homophones, different_pitch_homophones } => {
+                assert!(!pitch_accent.is_empty());
+                
+                // The word itself should be in true_homophones
+                let kousei_by_word = true_homophones.iter().find(|w| w.text == "構成");
+                assert!(kousei_by_word.is_some());
+                
+                // 後世 with different pitch should be in different_pitch_homophones
+                let kousei2 = different_pitch_homophones.iter().find(|w| w.text == "後世");
+                if kousei2.is_some() {
+                    assert!(!kousei2.unwrap().is_true_homophone);
+                }
+            }
+            _ => panic!("Expected UniqueMatch for specific word search")
         }
     }
 
     #[test]
     fn test_difficult_cases() {
         // Test cases that are known to be challenging
-        
+
         // 1. Multiple readings with different frequencies
         let results = find("かいとう");
         assert!(!results.is_empty());
         let kaitou = results.iter().find(|w| w.text == "回答");
         assert!(kaitou.is_some());
         assert!(kaitou.unwrap().frequency_score > 40000); // Should be common
-        
+
         // 2. Rare vs common words
-        let results = find("こうせい"); 
-        let kousei_freq = results.iter().find(|w| w.text == "構成").unwrap().frequency_score;
+        let results = find("こうせい");
+        let kousei_freq = results
+            .iter()
+            .find(|w| w.text == "構成")
+            .unwrap()
+            .frequency_score;
         let kousei_rare = results.iter().find(|w| w.text == "更正");
         if let Some(rare) = kousei_rare {
             assert!(kousei_freq > rare.frequency_score);
@@ -348,54 +449,113 @@ mod tests {
     fn test_pitch_accent_discrimination() {
         // When searching by reading, all should be true homophones
         let results = find_with_nhk("はし");
-        for word in &results {
-            assert!(word.is_true_homophone, "{} should be true homophone when searching by reading", word.text);
+        match results {
+            FindWithNhkResult::MultipleMatches { homophones } => {
+                for word in &homophones {
+                    assert!(
+                        word.is_true_homophone,
+                        "{} should be true homophone when searching by reading",
+                        word.text
+                    );
+                }
+            }
+            _ => panic!("Expected MultipleMatches for reading search")
         }
-        
+
         // Test searching by specific word
         let results_bridge = find_with_nhk("橋");
-        let bridge = results_bridge.iter().find(|w| w.text == "橋");
-        let chopsticks = results_bridge.iter().find(|w| w.text == "箸");
-        
-        if let (Some(b), Some(c)) = (bridge, chopsticks) {
-            assert!(b.is_true_homophone); // Query word should be true
-            if !b.pitch_accent.is_empty() && !c.pitch_accent.is_empty() {
-                // They should have different pitch accents
-                let have_common_pitch = b.pitch_accent.iter()
-                    .any(|p| c.pitch_accent.contains(p));
-                // If they have different pitches, chopsticks should be fake homophone
-                assert_eq!(c.is_true_homophone, have_common_pitch);
+        match results_bridge {
+            FindWithNhkResult::UniqueMatch { true_homophones, different_pitch_homophones, .. } => {
+                let bridge = true_homophones.iter().find(|w| w.text == "橋");
+                assert!(bridge.is_some(), "橋 should be in true_homophones");
+                
+                let chopsticks = different_pitch_homophones.iter().find(|w| w.text == "箸");
+                if chopsticks.is_some() {
+                    assert!(!chopsticks.unwrap().is_true_homophone, "箸 should be marked as fake homophone");
+                }
             }
+            _ => panic!("Expected UniqueMatch for specific word search")
         }
     }
 
     #[test]
     fn test_katakana_with_pitch() {
         let results = find_with_nhk("ソーセージ");
-        assert!(!results.is_empty());
-        
-        // Should find both ソーセージ and 双生児
-        let sausage = results.iter().find(|w| w.text == "ソーセージ");
-        let twins = results.iter().find(|w| w.text == "双生児");
-        
-        assert!(sausage.is_some());
-        assert!(twins.is_some());
-        
-        // Both should exist (the reading comparison was incorrect as ソーセージ may keep its katakana reading)
+        match results {
+            FindWithNhkResult::UniqueMatch { true_homophones, .. } => {
+                assert!(!true_homophones.is_empty());
+
+                // Should find both ソーセージ and 双生児
+                let sausage = true_homophones.iter().find(|w| w.text == "ソーセージ");
+                let twins = true_homophones.iter().find(|w| w.text == "双生児");
+
+                assert!(sausage.is_some());
+                assert!(twins.is_some());
+            }
+            FindWithNhkResult::MultipleMatches { homophones } => {
+                assert!(!homophones.is_empty());
+
+                // Should find both ソーセージ and 双生児
+                let sausage = homophones.iter().find(|w| w.text == "ソーセージ");
+                let twins = homophones.iter().find(|w| w.text == "双生児");
+
+                assert!(sausage.is_some());
+                assert!(twins.is_some());
+            }
+        }
     }
 
     #[test]
     fn test_multiple_pitch_accents() {
         let results = find_with_nhk("ていど");
         
-        // Find 程度
-        let teido = results.iter().find(|w| w.text == "程度");
-        assert!(teido.is_some());
+        match results {
+            FindWithNhkResult::MultipleMatches { homophones } => {
+                // Find 程度
+                let teido = homophones.iter().find(|w| w.text == "程度");
+                assert!(teido.is_some());
+
+                let teido = teido.unwrap();
+                // Should have multiple pitch accents (1 and 0)
+                assert!(
+                    teido.pitch_accent.len() > 1,
+                    "程度 should have multiple pitch accents"
+                );
+                assert!(
+                    teido.pitch_accent.contains(&1),
+                    "程度 should have pitch accent 1"
+                );
+                assert!(
+                    teido.pitch_accent.contains(&0),
+                    "程度 should have pitch accent 0"
+                );
+            }
+            _ => panic!("Expected MultipleMatches for reading search")
+        }
+    }
+
+    #[test]
+    fn test_nihongo_unique_match() {
+        // にほんご should return UniqueMatch when it uniquely identifies 日本語
+        let results = find_with_nhk("にほんご");
         
-        let teido = teido.unwrap();
-        // Should have multiple pitch accents (1 and 0)
-        assert!(teido.pitch_accent.len() > 1, "程度 should have multiple pitch accents");
-        assert!(teido.pitch_accent.contains(&1), "程度 should have pitch accent 1");
-        assert!(teido.pitch_accent.contains(&0), "程度 should have pitch accent 0");
+        match results {
+            FindWithNhkResult::UniqueMatch { pitch_accent: _, true_homophones, different_pitch_homophones } => {
+                // Should find 日本語
+                let nihongo = true_homophones.iter().find(|w| w.text == "日本語");
+                assert!(nihongo.is_some(), "Should find 日本語 in true_homophones");
+                
+                // Pitch accent may or may not be available in the data
+                // The important thing is that we get a UniqueMatch
+                
+                // Should be no other words with reading にほんご
+                assert_eq!(true_homophones.len() + different_pitch_homophones.len(), 1, 
+                    "にほんご should uniquely identify 日本語");
+            }
+            FindWithNhkResult::MultipleMatches { .. } => {
+                panic!("Expected UniqueMatch for にほんご as it uniquely identifies 日本語")
+            }
+        }
     }
 }
+


### PR DESCRIPTION
## Summary
- Changed `find_with_nhk` function to return `FindWithNhkResult` enum instead of `Vec<WordFrequencyWithPitch>`
- Added logic to distinguish between unique matches and multiple matches
- Updated all tests, examples, and documentation

## Changes
The new `FindWithNhkResult` enum has two variants:

1. **`UniqueMatch`** - Returned when:
   - Searching for a specific word (kanji) like "構成"
   - Searching for a reading that uniquely identifies one word like "にほんご" → "日本語"
   
   This variant separates true homophones (same pitch) from fake homophones (different pitch).

2. **`MultipleMatches`** - Returned when:
   - Searching for a reading that matches multiple different words like "こうせい"
   
   All results are considered true homophones in this case.

## Test Results
All tests pass successfully:
```
running 12 tests
............
test result: ok. 12 passed; 0 failed; 0 ignored
```

## Breaking Changes
This is a breaking change to the public API. Users of `find_with_nhk` will need to update their code to handle the new return type.

🤖 Generated with [Claude Code](https://claude.ai/code)