### PR TITLE
Refactor find_with_nhk to return descriptive FindWithNhkResult enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Rust library for finding **J**apanese **homo**phones and ranking them by frequ
 - Support for kanji, hiragana, and **katakana** input (ソーセージ and 双生児 are homophones)
 - Identify common vs uncommon words
 - Distinguish true homophones from "fake" homophones using NHK pitch accent data
-- Mark words with different pitch accents as fake homophones
+- Categorize results based on input type (unique word, reading, or no homophones)
 - Automatic katakana-to-hiragana conversion for searches
 
 ## Usage
@@ -37,23 +37,38 @@ for word in homophones {
 ### With NHK pitch accent data
 
 ```rust
-use jaydar::find_with_nhk;
+use jaydar::{find_with_nhk, FindWithNhkResult};
 
-let homophones = find_with_nhk("こうせい");
-for word in homophones {
-    println!("{} - pitch: {:?}, true homophone: {}", 
-        word.text,
-        word.pitch_accent,
-        word.is_true_homophone
-    );
+let result = find_with_nhk("構成");
+match result {
+    FindWithNhkResult::NoHomophones => {
+        println!("This word has no homophones");
+    }
+    FindWithNhkResult::UniqueMatch { true_homophones, different_pitch_homophones } => {
+        println!("True homophones (same pitch):");
+        for word in &true_homophones {
+            println!("  {} - pitch: {:?}", word.text, word.pitch_accent);
+        }
+        
+        println!("Fake homophones (different pitch):");
+        for word in &different_pitch_homophones {
+            println!("  {} - pitch: {:?}", word.text, word.pitch_accent);
+        }
+    }
+    FindWithNhkResult::MultipleMatches { homophones } => {
+        println!("Multiple matches found:");
+        for word in &homophones {
+            println!("  {} - pitch: {:?}", word.text, word.pitch_accent);
+        }
+    }
 }
 ```
 
-When searching for "構成" (pitch 0), words like "後世" (pitch 1) will be marked as fake homophones because they have different pitch accents.
+When searching for "構成" (pitch 0), words like "後世" (pitch 1) will be categorized as different pitch homophones.
 
 Example with multiple pitch accents:
 ```rust
-let homophones = find_with_nhk("ていど");
+let result = find_with_nhk("ていど");
 // 程度 will have pitch_accent: vec![1, 0] - both pronunciations are valid
 ```
 
@@ -85,10 +100,19 @@ Higher scores indicate more common words.
 
 ## Key Concepts
 
-### True vs Fake Homophones
+### Result Categories
 
-- **True homophones**: Words with the same reading AND pitch accent (e.g., 構成[0] and 公正[0])
-- **Fake homophones**: Words with the same reading but different pitch accent (e.g., 構成[0] and 後世[1])
+The `find_with_nhk` function returns three possible result types:
+
+1. **NoHomophones**: The word exists but has no other words with the same reading
+   - Example: 中国語, タピオカ, 前置き
+
+2. **UniqueMatch**: A specific word was searched (kanji/katakana), showing:
+   - **true_homophones**: Words with the same reading AND pitch accent (e.g., 構成[0] and 公正[0])
+   - **different_pitch_homophones**: Words with the same reading but different pitch accent (e.g., 構成[0] and 後世[1])
+
+3. **MultipleMatches**: A reading was searched (typically hiragana), returning all words with that reading
+   - Example: Searching for "こうせい" returns all words pronounced that way
 
 Note: Many Japanese words have multiple accepted pitch accents. For example, 程度 can be pronounced with either pitch accent 1 or 0. The library stores all accepted pitch accents in order of preference (most mainstream first).
 
@@ -142,8 +166,18 @@ pub struct WordFrequencyWithPitch {
     pub reading: String,
     pub frequency_score: u32,
     pub is_common: bool,
-    pub pitch_accent: Vec<u8>,        // Multiple pitch accents in order of preference
-    pub is_true_homophone: bool,      // false if different pitch from query
+    pub pitch_accent: Vec<u8>,  // Multiple pitch accents in order of preference
+}
+
+pub enum FindWithNhkResult {
+    NoHomophones,                        // Word has no homophones
+    UniqueMatch {                        // Specific word was searched
+        true_homophones: Vec<WordFrequencyWithPitch>,      // Same pitch
+        different_pitch_homophones: Vec<WordFrequencyWithPitch>, // Different pitch
+    },
+    MultipleMatches {                    // Reading was searched
+        homophones: Vec<WordFrequencyWithPitch>,
+    },
 }
 ```
 
@@ -154,7 +188,7 @@ pub struct WordFrequencyWithPitch {
 pub fn find(word: &str) -> Vec<WordFrequency>
 
 // Find homophones with pitch accent data
-pub fn find_with_nhk(word: &str) -> Vec<WordFrequencyWithPitch>
+pub fn find_with_nhk(word: &str) -> FindWithNhkResult
 ```
 
 ## License

--- a/examples/debug_kousei.rs
+++ b/examples/debug_kousei.rs
@@ -1,20 +1,36 @@
-use jaydar::find_with_nhk;
+use jaydar::{find_with_nhk, FindWithNhkResult};
 
 fn main() {
-    let results = find_with_nhk("こうせい");
+    let result = find_with_nhk("こうせい");
     
     println!("Results for こうせい:");
-    for word in &results {
-        println!("  Text: {}, Pitch: {:?}, True homophone: {}", 
-            word.text, word.pitch_accent, word.is_true_homophone);
+    match result {
+        FindWithNhkResult::MultipleMatches { homophones } => {
+            for word in &homophones {
+                println!("  Text: {}, Pitch: {:?}", 
+                    word.text, word.pitch_accent);
+            }
+        }
+        _ => println!("Unexpected result type"),
     }
     
     println!("\n\nResults for 構成:");
-    let results2 = find_with_nhk("構成");
-    for word in &results2 {
-        if word.text == "構成" || word.text == "後世" {
-            println!("  Text: {}, Pitch: {:?}, True homophone: {}", 
-                word.text, word.pitch_accent, word.is_true_homophone);
+    let result2 = find_with_nhk("構成");
+    match result2 {
+        FindWithNhkResult::UniqueMatch { true_homophones, different_pitch_homophones } => {
+            println!("  True homophones:");
+            for word in &true_homophones {
+                if word.text == "構成" || word.text == "後世" {
+                    println!("    Text: {}, Pitch: {:?}", word.text, word.pitch_accent);
+                }
+            }
+            println!("  Different pitch homophones:");
+            for word in &different_pitch_homophones {
+                if word.text == "構成" || word.text == "後世" {
+                    println!("    Text: {}, Pitch: {:?}", word.text, word.pitch_accent);
+                }
+            }
         }
+        _ => println!("Unexpected result type"),
     }
 }

--- a/examples/debug_sausage.rs
+++ b/examples/debug_sausage.rs
@@ -1,11 +1,24 @@
-use jaydar::find_with_nhk;
+use jaydar::{find_with_nhk, FindWithNhkResult};
 
 fn main() {
-    let results = find_with_nhk("ソーセージ");
+    let result = find_with_nhk("ソーセージ");
     
     println!("Results for ソーセージ:");
-    for word in &results {
-        println!("  Text: {}, Reading: {}, Pitch: {:?}", 
-            word.text, word.reading, word.pitch_accent);
+    match result {
+        FindWithNhkResult::NoHomophones => {
+            println!("  ソーセージ has no homophones");
+        }
+        FindWithNhkResult::UniqueMatch { true_homophones, .. } => {
+            for word in &true_homophones {
+                println!("  Text: {}, Reading: {}, Pitch: {:?}", 
+                    word.text, word.reading, word.pitch_accent);
+            }
+        }
+        FindWithNhkResult::MultipleMatches { homophones } => {
+            for word in &homophones {
+                println!("  Text: {}, Reading: {}, Pitch: {:?}", 
+                    word.text, word.reading, word.pitch_accent);
+            }
+        }
     }
 }

--- a/examples/demo_with_pitch.rs
+++ b/examples/demo_with_pitch.rs
@@ -1,45 +1,80 @@
-use jaydar::{find_with_nhk, WordFrequencyWithPitch};
+use jaydar::{find_with_nhk, FindWithNhkResult, WordFrequencyWithPitch};
 
 fn main() {
     // Example 1: Show pitch accent differences in こうせい
     println!("Homophones for 'こうせい' with pitch accent:");
-    let results = find_with_nhk("こうせい");
-    print_results_with_pitch(&results);
+    let result = find_with_nhk("こうせい");
+    print_results_with_pitch(result);
     
     println!("\n{}\n", "=".repeat(70));
     
     // Example 2: Search for 構成 (pitch 0) - shows "fake homophones"
     println!("Homophones for '構成' (pitch 0) - marking fake homophones:");
-    let results = find_with_nhk("構成");
-    print_results_with_pitch(&results);
+    let result = find_with_nhk("構成");
+    print_results_with_pitch(result);
     
     println!("\n{}\n", "=".repeat(70));
     
     // Example 3: Search for 後世 (pitch 1) - different fake homophones
     println!("Homophones for '後世' (pitch 1) - marking fake homophones:");
-    let results = find_with_nhk("後世");
-    print_results_with_pitch(&results);
+    let result = find_with_nhk("後世");
+    print_results_with_pitch(result);
     
     println!("\n{}\n", "=".repeat(70));
     
     // Example 4: Another common word with pitch variations
     println!("Homophones for 'はし' with pitch accent:");
-    let results = find_with_nhk("はし");
-    print_results_with_pitch(&results);
+    let result = find_with_nhk("はし");
+    print_results_with_pitch(result);
+    
+    println!("\n{}\n", "=".repeat(70));
+    
+    // Example 5: Words with no homophones
+    println!("Testing words with no homophones:");
+    println!("'後始末':");
+    let result = find_with_nhk("後始末");
+    print_results_with_pitch(result);
+    
+    println!("\n'タピオカ':");
+    let result = find_with_nhk("タピオカ");
+    print_results_with_pitch(result);
 }
 
-fn print_results_with_pitch(results: &[WordFrequencyWithPitch]) {
-    if results.is_empty() {
-        println!("No homophones found.");
-        return;
+fn print_results_with_pitch(result: FindWithNhkResult) {
+    match result {
+        FindWithNhkResult::NoHomophones => {
+            println!("This word has no homophones.");
+        }
+        FindWithNhkResult::UniqueMatch { true_homophones, different_pitch_homophones } => {
+            println!("Unique match found!");
+            
+            if !true_homophones.is_empty() {
+                println!("\nTrue homophones (same pitch):");
+                print_words_table(&true_homophones);
+            }
+            
+            if !different_pitch_homophones.is_empty() {
+                println!("\nFake homophones (different pitch):");
+                print_words_table(&different_pitch_homophones);
+            }
+            
+            println!("\nSummary: {} true homophones, {} fake homophones", 
+                true_homophones.len(), different_pitch_homophones.len());
+        }
+        FindWithNhkResult::MultipleMatches { homophones } => {
+            println!("Multiple matches found (searched by reading):");
+            print_words_table(&homophones);
+            println!("\nTotal homophones: {}", homophones.len());
+        }
     }
+}
+
+fn print_words_table(words: &[WordFrequencyWithPitch]) {
+    println!("{:<12} {:<15} {:<10} {:<8} {:<10}", 
+        "Text", "Reading", "Frequency", "Common?", "Pitch");
+    println!("{}", "-".repeat(55));
     
-    println!("Found {} homophones:", results.len());
-    println!("{:<12} {:<15} {:<10} {:<8} {:<10} {:<15}", 
-        "Text", "Reading", "Frequency", "Common?", "Pitch", "True Homophone?");
-    println!("{}", "-".repeat(70));
-    
-    for (i, word) in results.iter().enumerate() {
+    for (i, word) in words.iter().enumerate() {
         if i < 15 {  // Show top 15
             let pitch_str = if word.pitch_accent.is_empty() {
                 "?".to_string()
@@ -50,31 +85,18 @@ fn print_results_with_pitch(results: &[WordFrequencyWithPitch]) {
                     .join(", ")
             };
             
-            let homophone_str = if word.is_true_homophone {
-                "✓"
-            } else {
-                "✗ (fake)"
-            };
-            
             println!(
-                "{:<12} {:<15} {:<10} {:<8} {:<10} {:<15}",
+                "{:<12} {:<15} {:<10} {:<8} {:<10}",
                 word.text,
                 word.reading,
                 word.frequency_score,
                 if word.is_common { "Yes" } else { "No" },
-                pitch_str,
-                homophone_str
+                pitch_str
             );
         }
     }
     
-    if results.len() > 15 {
-        println!("... and {} more", results.len() - 15);
+    if words.len() > 15 {
+        println!("... and {} more", words.len() - 15);
     }
-    
-    // Count true vs fake homophones
-    let true_count = results.iter().filter(|w| w.is_true_homophone).count();
-    let fake_count = results.len() - true_count;
-    println!("\nSummary: {} true homophones, {} fake homophones (different pitch)", 
-        true_count, fake_count);
 }

--- a/examples/katakana_demo.rs
+++ b/examples/katakana_demo.rs
@@ -1,4 +1,4 @@
-use jaydar::{find, find_with_nhk};
+use jaydar::{find, find_with_nhk, FindWithNhkResult};
 
 fn main() {
     println!("=== Katakana Support Demo ===\n");
@@ -14,20 +14,32 @@ fn main() {
     
     // Test 2: With pitch accent data
     println!("\n2. カイ with pitch accent data:");
-    let results_pitch = find_with_nhk("カイ");
+    let result_pitch = find_with_nhk("カイ");
     println!("Top 5 results with pitch:");
-    for word in results_pitch.iter().take(5) {
-        println!("   {} - pitch: {:?}", word.text, word.pitch_accent);
+    match result_pitch {
+        FindWithNhkResult::MultipleMatches { homophones } => {
+            for word in homophones.iter().take(5) {
+                println!("   {} - pitch: {:?}", word.text, word.pitch_accent);
+            }
+        }
+        _ => println!("   Unexpected result type"),
     }
     
     // Test 3: Verify true/fake homophones
     println!("\n3. Searching from 会 (pitch 1) - checking fake homophones:");
-    let results_kai = find_with_nhk("会");
-    for word in results_kai.iter().filter(|w| ["会", "回", "階", "貝", "カイ"].contains(&w.text.as_str())) {
-        println!("   {} - pitch: {:?}, true homophone: {}", 
-            word.text, 
-            word.pitch_accent,
-            if word.is_true_homophone { "✓" } else { "✗ (different pitch)" });
+    let result_kai = find_with_nhk("会");
+    match result_kai {
+        FindWithNhkResult::UniqueMatch { true_homophones, different_pitch_homophones } => {
+            println!("   True homophones:");
+            for word in true_homophones.iter().filter(|w| ["会", "回", "階", "貝", "カイ"].contains(&w.text.as_str())) {
+                println!("      {} - pitch: {:?}", word.text, word.pitch_accent);
+            }
+            println!("   Different pitch homophones:");
+            for word in different_pitch_homophones.iter().filter(|w| ["会", "回", "階", "貝", "カイ"].contains(&w.text.as_str())) {
+                println!("      {} - pitch: {:?}", word.text, word.pitch_accent);
+            }
+        }
+        _ => println!("   Unexpected result type"),
     }
     
     // Test 4: Other katakana examples

--- a/examples/test_teido.rs
+++ b/examples/test_teido.rs
@@ -1,49 +1,53 @@
-use jaydar::find_with_nhk;
+use jaydar::{find_with_nhk, FindWithNhkResult};
 
 fn main() {
     println!("Testing 程度 (ていど) for multiple pitch accents:");
     
-    let results = find_with_nhk("ていど");
+    let result = find_with_nhk("ていど");
     
-    for word in &results {
-        if word.text == "程度" {
-            println!("\nFound 程度:");
-            println!("  Reading: {}", word.reading);
-            println!("  Pitch accents: {:?}", word.pitch_accent);
-            println!("  Frequency: {}", word.frequency_score);
-            println!("  Common: {}", word.is_common);
-            
-            if word.pitch_accent.len() > 1 {
-                println!("  ✓ Successfully has multiple pitch accents!");
-            } else {
-                println!("  ✗ Only has {} pitch accent(s)", word.pitch_accent.len());
+    match result {
+        FindWithNhkResult::MultipleMatches { homophones } => {
+            for word in &homophones {
+                if word.text == "程度" {
+                    println!("\nFound 程度:");
+                    println!("  Reading: {}", word.reading);
+                    println!("  Pitch accents: {:?}", word.pitch_accent);
+                    println!("  Frequency: {}", word.frequency_score);
+                    println!("  Common: {}", word.is_common);
+                    
+                    if word.pitch_accent.len() > 1 {
+                        println!("  ✓ Successfully has multiple pitch accents!");
+                    } else {
+                        println!("  ✗ Only has {} pitch accent(s)", word.pitch_accent.len());
+                    }
+                    
+                    if word.pitch_accent.contains(&1) && word.pitch_accent.contains(&0) {
+                        println!("  ✓ Has both pitch accents 1 and 0 as expected!");
+                    }
+                }
             }
             
-            if word.pitch_accent.contains(&1) && word.pitch_accent.contains(&0) {
-                println!("  ✓ Has both pitch accents 1 and 0 as expected!");
+            println!("\nAll homophones of ていど:");
+            for (i, word) in homophones.iter().enumerate() {
+                if i < 10 {
+                    let pitch_str = if word.pitch_accent.is_empty() {
+                        "?".to_string()
+                    } else {
+                        word.pitch_accent.iter()
+                            .map(|p| p.to_string())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    };
+                    
+                    println!("{:<10} ({:<10}) - pitch: {:<10} freq: {:<8}",
+                        word.text,
+                        word.reading,
+                        pitch_str,
+                        word.frequency_score
+                    );
+                }
             }
         }
-    }
-    
-    println!("\nAll homophones of ていど:");
-    for (i, word) in results.iter().enumerate() {
-        if i < 10 {
-            let pitch_str = if word.pitch_accent.is_empty() {
-                "?".to_string()
-            } else {
-                word.pitch_accent.iter()
-                    .map(|p| p.to_string())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            };
-            
-            println!("{:<10} ({:<10}) - pitch: {:<10} freq: {:<8} {}",
-                word.text,
-                word.reading,
-                pitch_str,
-                word.frequency_score,
-                if word.is_true_homophone { "✓" } else { "✗" }
-            );
-        }
+        _ => println!("Unexpected result type for ていど"),
     }
 }


### PR DESCRIPTION
## Summary
- Refactored `find_with_nhk` function to return a more descriptive `FindWithNhkResult` enum instead of `Vec<WordFrequencyWithPitch>`
- Removed `is_true_homophone` field from `WordFrequencyWithPitch` struct as it's now handled by the enum structure
- Improved API clarity by categorizing results into three distinct cases

## Changes
1. **New `FindWithNhkResult` enum** with three variants:
   - `NoHomophones`: Word exists but has no homophones (e.g., 中国語, タピオカ, にほんご)
   - `UniqueMatch`: Specific word was searched, with homophones divided by pitch accent
   - `MultipleMatches`: Reading was searched, returning all matching words

2. **Updated `WordFrequencyWithPitch` struct**:
   - Removed `is_true_homophone` field
   - Cleaner struct focused only on word data

3. **Improved logic** for determining result types:
   - Handles edge cases like words with multiple readings (e.g., タピオカ with both katakana and hiragana readings)
   - Correctly identifies when a word has no homophones

## Test plan
- [x] All existing tests updated and passing
- [x] Added new test cases for `NoHomophones` variant
- [x] Updated all examples to use new API
- [x] Tested with various inputs including kanji, hiragana, and katakana

## Breaking changes
This is a breaking change for users of the `find_with_nhk` function. The migration is straightforward:

```rust
// Old API
let words = find_with_nhk("こうせい");
for word in words {
    if word.is_true_homophone { /* ... */ }
}

// New API
let result = find_with_nhk("こうせい");
match result {
    FindWithNhkResult::NoHomophones => { /* ... */ }
    FindWithNhkResult::UniqueMatch { true_homophones, different_pitch_homophones } => { /* ... */ }
    FindWithNhkResult::MultipleMatches { homophones } => { /* ... */ }
}
```

🤖 Generated with [Claude Code](https://claude.ai/code)